### PR TITLE
Improve supervisord configuration

### DIFF
--- a/supervisord.ini
+++ b/supervisord.ini
@@ -6,9 +6,11 @@ command=monetdbd start /var/monetdb5/dbfarm
 autorestart=false
 user=monetdb
 priority=1
+exitcodes=0
 
 [program:monetdb]
 command=monetdb start db
 autorestart=false
 user=monetdb
 priority=2
+exitcodes=1

--- a/supervisord.ini
+++ b/supervisord.ini
@@ -5,8 +5,10 @@ nodaemon=true
 command=monetdbd start /var/monetdb5/dbfarm
 autorestart=true
 user=monetdb
+priority=1
 
 [program:monetdb]
 command=monetdb start db
 autorestart=true
 user=monetdb
+priority=2

--- a/supervisord.ini
+++ b/supervisord.ini
@@ -7,6 +7,7 @@ autorestart=false
 user=monetdb
 priority=1
 exitcodes=0
+startsecs=0
 
 [program:monetdb]
 command=monetdb start db
@@ -14,3 +15,4 @@ autorestart=false
 user=monetdb
 priority=2
 exitcodes=1
+startsecs=0

--- a/supervisord.ini
+++ b/supervisord.ini
@@ -3,12 +3,12 @@ nodaemon=true
 
 [program:monetdbd]
 command=monetdbd start /var/monetdb5/dbfarm
-autorestart=true
+autorestart=false
 user=monetdb
 priority=1
 
 [program:monetdb]
 command=monetdb start db
-autorestart=true
+autorestart=false
 user=monetdb
 priority=2


### PR DESCRIPTION
Supervisord expects applications to run in the background, while monetdb and monetdbd are expected to run in the backgroup. With the previous configuration, supervisord tried to restart the applications, although this was not necessary. This resulted in the log messages. With this configuration, monetdb and monetdbd are started in the right order and there are no attempts to restart. This should solve https://github.com/MonetDB/monetdb-r-docker/issues/1
